### PR TITLE
ホワイトリストを作成するコマンドを追加

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newCreateCmd() *cobra.Command {
+	var createCmd = &cobra.Command{
+		Use:   "create",
+		Short: "`sqd create` collect query and create whitelist",
+		Long:  "`sqd create` collect query and create whitelist",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	return createCmd
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -20,7 +20,6 @@ func newCreateCmd() *cobra.Command {
 				cmd.Help()
 				return nil
 			}
-
 			lister.Create(os.Stdin, output)
 
 			return nil

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -9,8 +9,6 @@ import (
 )
 
 func newCreateCmd() *cobra.Command {
-	var output string
-
 	var createCmd = &cobra.Command{
 		Use:   "create",
 		Short: "`sqd create` collect query and create whitelist",
@@ -20,13 +18,11 @@ func newCreateCmd() *cobra.Command {
 				cmd.Help()
 				return nil
 			}
-			lister.Create(os.Stdin, output)
+			lister.Create(os.Stdin, os.Stdout)
 
 			return nil
 		},
 	}
-
-	createCmd.Flags().StringVarP(&output, "output", "o", "whitelist", "output path of whitelist file(default: ./whitelist)")
 
 	return createCmd
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,16 +1,15 @@
 package cmd
 
 import (
-	"bufio"
 	"os"
 
-	"github.com/Komei22/sql-mask"
+	"github.com/Komei22/sqd/lister"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
 func newCreateCmd() *cobra.Command {
-	var filepath string
+	var output string
 
 	var createCmd = &cobra.Command{
 		Use:   "create",
@@ -22,30 +21,13 @@ func newCreateCmd() *cobra.Command {
 				return nil
 			}
 
-			file, err := os.Create(filepath)
-			if err != nil {
-				return err
-			}
-			defer file.Close()
-
-			scanner := bufio.NewScanner(os.Stdin)
-			for scanner.Scan() {
-				if err := scanner.Err(); err != nil {
-					return err
-				}
-				query := scanner.Text()
-				queryStruct, err := parser.Parse(query)
-				if err != nil {
-					return err
-				}
-				file.Write(([]byte)(queryStruct + "\n"))
-			}
+			lister.Create(os.Stdin, output)
 
 			return nil
 		},
 	}
 
-	createCmd.Flags().StringVarP(&filepath, "output", "o", "whitelist", "output path of whitelist file(default: ./whitelist)")
+	createCmd.Flags().StringVarP(&output, "output", "o", "whitelist", "output path of whitelist file(default: ./whitelist)")
 
 	return createCmd
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -18,8 +18,15 @@ func newCreateCmd() *cobra.Command {
 				cmd.Help()
 				return nil
 			}
-			lister.Create(os.Stdin, os.Stdout)
 
+			list, err := lister.Create(os.Stdin)
+			if err != nil {
+				return err
+			}
+
+			for q := range list.Iter() {
+				cmd.Println(q)
+			}
 			return nil
 		},
 	}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,17 +1,51 @@
 package cmd
 
 import (
+	"bufio"
+	"os"
+
+	"github.com/Komei22/sql-mask"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func newCreateCmd() *cobra.Command {
+	var filepath string
+
 	var createCmd = &cobra.Command{
 		Use:   "create",
 		Short: "`sqd create` collect query and create whitelist",
-		Long:  "`sqd create` collect query and create whitelist",
+		Long:  "`sqd create` collect query from stdin and create whitelist",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if terminal.IsTerminal(0) {
+				cmd.Help()
+				return nil
+			}
+
+			file, err := os.Create(filepath)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+
+			scanner := bufio.NewScanner(os.Stdin)
+			for scanner.Scan() {
+				if err := scanner.Err(); err != nil {
+					return err
+				}
+				query := scanner.Text()
+				queryStruct, err := parser.Parse(query)
+				if err != nil {
+					return err
+				}
+				file.Write(([]byte)(queryStruct + "\n"))
+			}
+
 			return nil
 		},
 	}
+
+	createCmd.Flags().StringVarP(&filepath, "output", "o", "whitelist", "output path of whitelist file(default: ./whitelist)")
+
 	return createCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,8 @@ func newRootCmd() *cobra.Command {
 	rootCmd.Flags().StringVarP(&whitelist, "Whitelist", "W", "", "whitelist file path")
 	rootCmd.Flags().StringVarP(&blacklist, "Blacklist", "B", "", "blacklist file path")
 
+	rootCmd.AddCommand(newCreateCmd())
+
 	return rootCmd
 }
 

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,0 +1,16 @@
+package formatter
+
+import (
+	"strings"
+)
+
+// TrimControlChara remove control charactor
+func TrimControlChara(query string) string {
+	query = query[1:strings.LastIndex(query, "\"")]
+	removeStr := []string{"\\n", "\\t"}
+	for _, str := range removeStr {
+		query = strings.Replace(query, str, " ", -1)
+	}
+	query = strings.Replace(query, "\\", "", -1)
+	return query
+}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,16 +1,20 @@
 package formatter
 
 import (
+	"regexp"
 	"strings"
 )
 
-// TrimControlChara remove control charactor
-func TrimControlChara(query string) string {
+var multiSpaceRegexp = regexp.MustCompile(" {2,}")
+
+// Format remove control charactor
+func Format(query string) string {
 	query = query[1:strings.LastIndex(query, "\"")]
 	removeStr := []string{"\\n", "\\t"}
 	for _, str := range removeStr {
 		query = strings.Replace(query, str, " ", -1)
 	}
 	query = strings.Replace(query, "\\", "", -1)
+	query = multiSpaceRegexp.ReplaceAllString(query, " ")
 	return query
 }

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -9,7 +9,6 @@ var multiSpaceRegexp = regexp.MustCompile(" {2,}")
 
 // Format remove control charactor
 func Format(query string) string {
-	query = query[1:strings.LastIndex(query, "\"")]
 	removeStr := []string{"\\n", "\\t"}
 	for _, str := range removeStr {
 		query = strings.Replace(query, str, " ", -1)

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	query := `"SELECT * FROM users\nWHERE\n\tname = "test""`
+	query := `SELECT * FROM         users\nWHERE\n\tname = "test"`
 	expect := `SELECT * FROM users WHERE name = "test"`
 
 	formattedQuery := Format(query)

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,0 +1,16 @@
+package formatter
+
+import (
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	query := `"SELECT * FROM users\nWHERE\n\tname = "test""`
+	expect := `SELECT * FROM users WHERE name = "test"`
+
+	formattedQuery := Format(query)
+
+	if formattedQuery != expect {
+		t.Errorf("Unexpected fomatted query: %s", formattedQuery)
+	}
+}

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -2,7 +2,6 @@ package lister
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 
 	"github.com/Komei22/sqd/formatter"
@@ -11,24 +10,20 @@ import (
 )
 
 // Create whitelist
-func Create(r io.Reader, w io.Writer) error {
+func Create(r io.Reader) (mapset.Set, error) {
 	list := mapset.NewSet()
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		if err := scanner.Err(); err != nil {
-			return err
+			return nil, err
 		}
 		query := formatter.Format(scanner.Text())
 		queryStruct, err := parser.Parse(query)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		list.Add(queryStruct)
 	}
 
-	for q := range list.Iter() {
-		fmt.Fprintln(w, q)
-	}
-
-	return nil
+	return list, nil
 }

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -2,11 +2,10 @@ package lister
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"os"
-	"strings"
 
+	"github.com/Komei22/sqd/formatter"
 	"github.com/Komei22/sql-mask"
 	"github.com/deckarep/golang-set"
 )
@@ -19,9 +18,7 @@ func Create(r io.Reader, output string) error {
 		if err := scanner.Err(); err != nil {
 			return err
 		}
-		query := scanner.Text()
-		fomatedQuery := trimControlChara(query)
-		fmt.Println(fomatedQuery)
+		query := formatter.TrimControlChara(scanner.Text())
 		queryStruct, err := parser.Parse(query)
 		if err != nil {
 			return err
@@ -45,11 +42,4 @@ func save(filepath string, list mapset.Set) error {
 		file.Write(([]byte)(q.(string) + "\n"))
 	}
 	return nil
-}
-
-func trimControlChara(query string) string {
-	query = query[1:strings.LastIndex(query, "\"")]
-	query = strings.Replace(query, "\\n", " ", -1)
-	query = strings.Replace(query, "\\", "", -1)
-	return query
 }

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -1,0 +1,32 @@
+package lister
+
+import (
+	"bufio"
+	"io"
+	"os"
+
+	"github.com/Komei22/sql-mask"
+)
+
+// Create whitelist
+func Create(r io.Reader, output string) error {
+	file, err := os.Create(output)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+		query := scanner.Text()
+		queryStruct, err := parser.Parse(query)
+		if err != nil {
+			return err
+		}
+		file.Write(([]byte)(queryStruct + "\n"))
+	}
+	return nil
+}

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -3,6 +3,7 @@ package lister
 import (
 	"bufio"
 	"io"
+	"strings"
 
 	"github.com/Komei22/sqd/formatter"
 	"github.com/Komei22/sql-mask"
@@ -17,8 +18,10 @@ func Create(r io.Reader) (mapset.Set, error) {
 		if err := scanner.Err(); err != nil {
 			return nil, err
 		}
-		query := formatter.Format(scanner.Text())
+		in := scanner.Text()
+		query := in[1:strings.LastIndex(in, "\"")]
 		queryStruct, err := parser.Parse(query)
+		queryStruct = formatter.Format(queryStruct)
 		if err != nil {
 			return nil, err
 		}

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -2,8 +2,8 @@ package lister
 
 import (
 	"bufio"
+	"fmt"
 	"io"
-	"os"
 
 	"github.com/Komei22/sqd/formatter"
 	"github.com/Komei22/sql-mask"
@@ -11,7 +11,7 @@ import (
 )
 
 // Create whitelist
-func Create(r io.Reader, output string) error {
+func Create(r io.Reader, w io.Writer) error {
 	list := mapset.NewSet()
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -26,20 +26,9 @@ func Create(r io.Reader, output string) error {
 		list.Add(queryStruct)
 	}
 
-	return save(output, list)
-}
-
-func save(filepath string, list mapset.Set) error {
-	file, err := os.Create(filepath)
-	if err != nil {
-		return err
+	for q := range list.Iter() {
+		fmt.Fprintln(w, q)
 	}
-	defer file.Close()
 
-	it := list.Iterator()
-
-	for q := range it.C {
-		file.Write(([]byte)(q.(string) + "\n"))
-	}
 	return nil
 }

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -6,16 +6,12 @@ import (
 	"os"
 
 	"github.com/Komei22/sql-mask"
+	"github.com/deckarep/golang-set"
 )
 
 // Create whitelist
 func Create(r io.Reader, output string) error {
-	file, err := os.Create(output)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
+	list := mapset.NewSet()
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		if err := scanner.Err(); err != nil {
@@ -26,7 +22,23 @@ func Create(r io.Reader, output string) error {
 		if err != nil {
 			return err
 		}
-		file.Write(([]byte)(queryStruct + "\n"))
+		list.Add(queryStruct)
+	}
+
+	return save(output, list)
+}
+
+func save(filepath string, list mapset.Set) error {
+	file, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	it := list.Iterator()
+
+	for q := range it.C {
+		file.Write(([]byte)(q.(string) + "\n"))
 	}
 	return nil
 }

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -18,7 +18,7 @@ func Create(r io.Reader, w io.Writer) error {
 		if err := scanner.Err(); err != nil {
 			return err
 		}
-		query := formatter.TrimControlChara(scanner.Text())
+		query := formatter.Format(scanner.Text())
 		queryStruct, err := parser.Parse(query)
 		if err != nil {
 			return err

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -2,8 +2,10 @@ package lister
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/Komei22/sql-mask"
 	"github.com/deckarep/golang-set"
@@ -18,6 +20,8 @@ func Create(r io.Reader, output string) error {
 			return err
 		}
 		query := scanner.Text()
+		fomatedQuery := trimControlChara(query)
+		fmt.Println(fomatedQuery)
 		queryStruct, err := parser.Parse(query)
 		if err != nil {
 			return err
@@ -41,4 +45,11 @@ func save(filepath string, list mapset.Set) error {
 		file.Write(([]byte)(q.(string) + "\n"))
 	}
 	return nil
+}
+
+func trimControlChara(query string) string {
+	query = query[1:strings.LastIndex(query, "\"")]
+	query = strings.Replace(query, "\\n", " ", -1)
+	query = strings.Replace(query, "\\", "", -1)
+	return query
 }

--- a/lister/lister_test.go
+++ b/lister/lister_test.go
@@ -1,0 +1,21 @@
+package lister
+
+import (
+	"github.com/deckarep/golang-set"
+	"strings"
+	"testing"
+)
+
+func TestCreateUniqueQuerylist(t *testing.T) {
+	queries := `"SELECT * FROM user WHERE name = "test""
+"SELECT * FROM user WHERE name = "test""
+"SELECT * FROM user"`
+	expectList := mapset.NewSet("SELECT * FROM user WHERE name = ?", "SELECT * FROM user")
+
+	list, _ := Create(strings.NewReader(queries))
+
+	if !expectList.Equal(list) {
+		t.Errorf("Unexpected list: %s", list)
+		t.Errorf("Expected list: %s", expectList)
+	}
+}


### PR DESCRIPTION
標準入力からクエリを受け取り、クエリ構造に変換してファイルに保存することで、ホワイトリストを作成するコマンドを追加します。
