### PR TITLE
検知のときにクエリを整形するようにする

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -3,7 +3,6 @@ package detector
 import (
 	"bufio"
 	"io"
-	"strings"
 
 	"github.com/Komei22/sqd/formatter"
 	"github.com/Komei22/sqd/matcher"
@@ -55,7 +54,10 @@ func (d *Detector) DetectFrom(r io.Reader, suspiciousQueryChan chan<- string, er
 			errChan <- err
 		}
 		in := scanner.Text()
-		query := in[1:strings.LastIndex(in, "\"")]
+		query, err := formatter.ExtractQueryFrom(in)
+		if err != nil {
+			errChan <- err
+		}
 		suspiciousQuery, err := d.Detect(query)
 		if err != nil {
 			errChan <- err

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -3,7 +3,9 @@ package detector
 import (
 	"bufio"
 	"io"
+	"strings"
 
+	"github.com/Komei22/sqd/formatter"
 	"github.com/Komei22/sqd/matcher"
 	"github.com/Komei22/sql-mask"
 )
@@ -35,6 +37,7 @@ func New(m *matcher.Matcher, mode Mode) *Detector {
 // Detect suspicious query
 func (d *Detector) Detect(query string) (string, error) {
 	q, err := parser.Parse(query)
+	q = formatter.Format(q)
 	if err != nil {
 		return "", err
 	}
@@ -51,7 +54,8 @@ func (d *Detector) DetectFrom(r io.Reader, suspiciousQueryChan chan<- string, er
 		if err := scanner.Err(); err != nil {
 			errChan <- err
 		}
-		query := scanner.Text()
+		in := scanner.Text()
+		query := in[1:strings.LastIndex(in, "\"")]
 		suspiciousQuery, err := d.Detect(query)
 		if err != nil {
 			errChan <- err

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -11,9 +11,9 @@ func TestDetectSuspiciousQueriesUsingBlacklist(t *testing.T) {
 	blacklist := `DROP DATABASE test
 DROP TABLE article`
 
-	queries := `"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT ?"
-"DELETE FROM articles WHERE articles.id = ?"
-"INSERT INTO articles (title, content, created_at, updated_at) VALUES (?, ?, ?, ?)"
+	queries := `"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 10"
+"DELETE FROM articles WHERE articles.id = 1"
+" INSERT INTO articles (title, content, created_at, updated_at) VALUES ('hoge', 'hogehoge', '2018-11-01 09:53:37', '2018-11-01 09:53:37')"
 "DROP DATABASE test"
 "DROP TABLE article"`
 
@@ -53,9 +53,9 @@ func TestDetectSuspiciousQueriesUsingwhitelist(t *testing.T) {
 DELETE FROM articles WHERE articles.id = ?
 INSERT INTO articles (title, content, created_at, updated_at) VALUES (?, ?, ?, ?)`
 
-	queries := `"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT ?"
-"DELETE FROM articles WHERE articles.id = ?"
-"INSERT INTO articles (title, content, created_at, updated_at) VALUES (?, ?, ?, ?)"
+	queries := `"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 10"
+"DELETE FROM articles WHERE articles.id = 1"
+" INSERT INTO articles (title, content, created_at, updated_at) VALUES ('hoge', 'hogehoge', '2018-11-01 09:53:37', '2018-11-01 09:53:37')"
 "DROP DATABASE test"
 "DROP TABLE article"`
 

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -11,11 +11,11 @@ func TestDetectSuspiciousQueriesUsingBlacklist(t *testing.T) {
 	blacklist := `DROP DATABASE test
 DROP TABLE article`
 
-	queries := `SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT ?
-DELETE FROM articles WHERE articles.id = ?
-INSERT INTO articles (title, content, created_at, updated_at) VALUES (?, ?, ?, ?)
-DROP DATABASE test
-DROP TABLE article`
+	queries := `"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT ?"
+"DELETE FROM articles WHERE articles.id = ?"
+"INSERT INTO articles (title, content, created_at, updated_at) VALUES (?, ?, ?, ?)"
+"DROP DATABASE test"
+"DROP TABLE article"`
 
 	illegalQueries := []string{
 		"DROP DATABASE test",
@@ -53,11 +53,11 @@ func TestDetectSuspiciousQueriesUsingwhitelist(t *testing.T) {
 DELETE FROM articles WHERE articles.id = ?
 INSERT INTO articles (title, content, created_at, updated_at) VALUES (?, ?, ?, ?)`
 
-	queries := `SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT ?
-DELETE FROM articles WHERE articles.id = ?
-INSERT INTO articles (title, content, created_at, updated_at) VALUES (?, ?, ?, ?)
-DROP DATABASE test
-DROP TABLE article`
+	queries := `"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT ?"
+"DELETE FROM articles WHERE articles.id = ?"
+"INSERT INTO articles (title, content, created_at, updated_at) VALUES (?, ?, ?, ?)"
+"DROP DATABASE test"
+"DROP TABLE article"`
 
 	illegalQueries := []string{
 		"DROP DATABASE test",

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,6 +1,7 @@
 package formatter
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -16,4 +17,13 @@ func Format(query string) string {
 	query = strings.Replace(query, "\\", "", -1)
 	query = multiSpaceRegexp.ReplaceAllString(query, " ")
 	return query
+}
+
+// ExtractQueryFrom input
+func ExtractQueryFrom(in string) (string, error) {
+	lastIdx := len(in) - 1
+	if string(in[0]) != "\"" || string(in[lastIdx]) != "\"" {
+		return "", fmt.Errorf("Invalid input format: %s", in)
+	}
+	return in[1:lastIdx], nil
 }

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -3,7 +3,6 @@ package lister
 import (
 	"bufio"
 	"io"
-	"strings"
 
 	"github.com/Komei22/sqd/formatter"
 	"github.com/Komei22/sql-mask"
@@ -19,7 +18,10 @@ func Create(r io.Reader) (mapset.Set, error) {
 			return nil, err
 		}
 		in := scanner.Text()
-		query := in[1:strings.LastIndex(in, "\"")]
+		query, err := formatter.ExtractQueryFrom(in)
+		if err != nil {
+			return nil, err
+		}
 		queryStruct, err := parser.Parse(query)
 		queryStruct = formatter.Format(queryStruct)
 		if err != nil {


### PR DESCRIPTION
改行を含んだクエリの入力を受け付けられるようにするために、検知時もクエリを整形した後に、リストと照合するようにします。

実行例
```.sh
$ cat ~/Desktop/testdata/blacklist
SELECT * FROM articles
DROP TABLE articles
DROP

$ echo -e "\"SELECT *          FROM\\\n articles\"" | sqd -B ~/Desktop/testdata/blacklist
SELECT *          FROM\n articles

```
上記の例では、`SELECT * FROM articles`がブラックリストに載っていて、`SELECT *          FROM\n articles`のように改行や複数のスペースが含まれていても、同じクエリと認識して検知する。