### PR TITLE
入力に含まれるエスケープ文字に対応

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Komei22/sqd/lister"
@@ -25,7 +26,7 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			for q := range list.Iter() {
-				cmd.Println(q)
+				fmt.Fprintln(os.Stdout, q)
 			}
 			return nil
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func newRootCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("Can't detection suspicious query: %s", err)
 				}
-				cmd.Println(suspiciousQuery)
+				fmt.Fprintln(os.Stdout, suspiciousQuery)
 			} else {
 				if terminal.IsTerminal(0) {
 					cmd.Help()

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -35,8 +35,8 @@ func New(m *matcher.Matcher, mode Mode) *Detector {
 
 // Detect suspicious query
 func (d *Detector) Detect(query string) (string, error) {
-	q, err := parser.Parse(query)
-	q = formatter.Format(q)
+	q := formatter.Format(query)
+	q, err := parser.Parse(q)
 	if err != nil {
 		return "", err
 	}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -14,7 +14,9 @@ func Format(query string) string {
 	for _, str := range removeStr {
 		query = strings.Replace(query, str, " ", -1)
 	}
-	query = strings.Replace(query, "\\", "", -1)
+	query = strings.Replace(query, `\\`, `\`, -1)
+	query = strings.Replace(query, `\"`, `"`, -1)
+	query = strings.Replace(query, `\'`, `'`, -1)
 	query = multiSpaceRegexp.ReplaceAllString(query, " ")
 	return query
 }

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -14,9 +14,9 @@ func Format(query string) string {
 	for _, str := range removeStr {
 		query = strings.Replace(query, str, " ", -1)
 	}
-	query = strings.Replace(query, `\\`, `\`, -1)
 	query = strings.Replace(query, `\"`, `"`, -1)
 	query = strings.Replace(query, `\'`, `'`, -1)
+	query = strings.Replace(query, `\\`, `\`, -1)
 	query = multiSpaceRegexp.ReplaceAllString(query, " ")
 	return query
 }

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -5,12 +5,20 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	query := `SELECT * FROM         users\nWHERE\n\tname = "test"`
-	expect := `SELECT * FROM users WHERE name = "test"`
+	queries := []string{
+		`SELECT * FROM         users\nWHERE\n\tname = \"test\"`,
+		`SELECT * FROM users WHERE name = \'te\\st\'`}
+	expects := []string{
+		`SELECT * FROM users WHERE name = "test"`,
+		`SELECT * FROM users WHERE name = 'te\st'`}
 
-	formattedQuery := Format(query)
-
-	if formattedQuery != expect {
-		t.Errorf("Unexpected fomatted query: %s", formattedQuery)
+	var formattedQueries []string
+	for _, q := range queries {
+		formattedQueries = append(formattedQueries, Format(q))
+	}
+	for i, fq := range formattedQueries {
+		if fq != expects[i] {
+			t.Errorf("Unexpected fomatted query: %s", fq)
+		}
 	}
 }

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -7,10 +7,10 @@ import (
 func TestFormat(t *testing.T) {
 	queries := []string{
 		`SELECT * FROM         users\nWHERE\n\tname = \"test\"`,
-		`SELECT * FROM users WHERE name = \'te\\st\'`}
+		`SELECT * FROM users WHERE name = \'te\\\"st\'`}
 	expects := []string{
 		`SELECT * FROM users WHERE name = "test"`,
-		`SELECT * FROM users WHERE name = 'te\st'`}
+		`SELECT * FROM users WHERE name = 'te\"st'`}
 
 	var formattedQueries []string
 	for _, q := range queries {

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -22,8 +22,8 @@ func Create(r io.Reader) (mapset.Set, error) {
 		if err != nil {
 			return nil, err
 		}
+		query = formatter.Format(query)
 		queryStruct, err := parser.Parse(query)
-		queryStruct = formatter.Format(queryStruct)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
tcpdpが出力するクエリログは，以下の例のように，エスケープ文字としてのバックスラッシュを含んでいる．

tcpdpのクエリログの例：`SELECT * FROM users WHERE name = \"test\"`

このバックスラッシュは，クエリ構造への変換を行う時，SQL文においてのエスケープ文字として扱うため，変換処理が正常に行われない．そのため，クエリの整形時にエスケープ文字は排除しておく．

