### PR TITLE
入力のフォーマットを変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ DROP TABLE articles
 
 ```
 $ cat query.log
-"INSERT INTO articles (title, content, created_at, updated_at) VALUES ('hoge', 'fuga', '2018-11-01 09:53:37', '2018-11-01 09:53:37')"
-"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 30"
-"DELETE FROM articles WHERE articles.id = 1"
+INSERT INTO articles (title, content, created_at, updated_at) VALUES ('hoge', 'fuga', '2018-11-01 09:53:37', '2018-11-01 09:53:37')
+SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 30
+DELETE FROM articles WHERE articles.id = 1
 
 $ cat query.log | sqd create
 DELETE FROM articles WHERE articles.id = ?
@@ -41,10 +41,10 @@ Query log are written one query in one line such as the following example.
 
 Example of query log
 ```
-"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 1"
-"DELETE FROM\narticles\nWHERE\narticles.id = 1"
-"SELECT * FROM articles"
-"DROP TABLE articles"
+SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 1
+DELETE FROM\narticles\nWHERE\narticles.id = 1
+SELECT * FROM articles
+DROP TABLE articles
 ```
 
 List file are written one structure of query in one line such as the following example.

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Komei22/sqd/lister"
@@ -25,7 +26,7 @@ func newCreateCmd() *cobra.Command {
 			}
 
 			for q := range list.Iter() {
-				cmd.Println(q)
+				fmt.Fprintln(os.Stdout, q)
 			}
 			return nil
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func newRootCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("Can't detection suspicious query: %s", err)
 				}
-				cmd.Println(suspiciousQuery)
+				fmt.Fprintln(os.Stdout, suspiciousQuery)
 			} else {
 				if terminal.IsTerminal(0) {
 					cmd.Help()

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -53,11 +53,7 @@ func (d *Detector) DetectFrom(r io.Reader, suspiciousQueryChan chan<- string, er
 		if err := scanner.Err(); err != nil {
 			errChan <- err
 		}
-		in := scanner.Text()
-		query, err := formatter.ExtractQueryFrom(in)
-		if err != nil {
-			errChan <- err
-		}
+		query := scanner.Text()
 		suspiciousQuery, err := d.Detect(query)
 		if err != nil {
 			errChan <- err

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -11,11 +11,11 @@ func TestDetectSuspiciousQueriesUsingBlacklist(t *testing.T) {
 	blacklist := `DROP DATABASE test
 DROP TABLE article`
 
-	queries := `"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 10"
-"DELETE FROM articles WHERE articles.id = 1"
-" INSERT INTO articles (title, content, created_at, updated_at) VALUES ('hoge', 'hogehoge', '2018-11-01 09:53:37', '2018-11-01 09:53:37')"
-"DROP DATABASE test"
-"DROP TABLE article"`
+	queries := `SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 10
+DELETE FROM articles WHERE articles.id =
+INSERT INTO articles (title, content, created_at, updated_at) VALUES ('hoge', 'hogehoge', '2018-11-01 09:53:37', '2018-11-01 09:53:37')
+DROP DATABASE test
+DROP TABLE article`
 
 	illegalQueries := []string{
 		"DROP DATABASE test",
@@ -53,11 +53,11 @@ func TestDetectSuspiciousQueriesUsingwhitelist(t *testing.T) {
 DELETE FROM articles WHERE articles.id = ?
 INSERT INTO articles (title, content, created_at, updated_at) VALUES (?, ?, ?, ?)`
 
-	queries := `"SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 10"
-"DELETE FROM articles WHERE articles.id = 1"
-" INSERT INTO articles (title, content, created_at, updated_at) VALUES ('hoge', 'hogehoge', '2018-11-01 09:53:37', '2018-11-01 09:53:37')"
-"DROP DATABASE test"
-"DROP TABLE article"`
+	queries := `SELECT articles.* FROM articles ORDER BY articles.id DESC LIMIT 10
+DELETE FROM articles WHERE articles.id = 1
+INSERT INTO articles (title, content, created_at, updated_at) VALUES ('hoge', 'hogehoge', '2018-11-01 09:53:37', '2018-11-01 09:53:37')
+DROP DATABASE test
+DROP TABLE article`
 
 	illegalQueries := []string{
 		"DROP DATABASE test",

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,7 +1,6 @@
 package formatter
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -10,20 +9,7 @@ var multiSpaceRegexp = regexp.MustCompile(" {2,}")
 
 // Format remove control charactor
 func Format(query string) string {
-	removeStr := []string{"\\n", "\\t"}
-	for _, str := range removeStr {
-		query = strings.Replace(query, str, " ", -1)
-	}
-	query = strings.Replace(query, "\\", "", -1)
+	query = strings.Replace(query, "\t", " ", -1)
 	query = multiSpaceRegexp.ReplaceAllString(query, " ")
 	return query
-}
-
-// ExtractQueryFrom input
-func ExtractQueryFrom(in string) (string, error) {
-	lastIdx := len(in) - 1
-	if string(in[0]) != "\"" || string(in[lastIdx]) != "\"" {
-		return "", fmt.Errorf("Invalid input format: %s", in)
-	}
-	return in[1:lastIdx], nil
 }

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	query := `SELECT * FROM         users\nWHERE\n\tname = "test"`
+	query := `SELECT * FROM         users WHERE		name = "test"`
 	expect := `SELECT * FROM users WHERE name = "test"`
 
 	formattedQuery := Format(query)

--- a/lister/lister.go
+++ b/lister/lister.go
@@ -17,11 +17,7 @@ func Create(r io.Reader) (mapset.Set, error) {
 		if err := scanner.Err(); err != nil {
 			return nil, err
 		}
-		in := scanner.Text()
-		query, err := formatter.ExtractQueryFrom(in)
-		if err != nil {
-			return nil, err
-		}
+		query := scanner.Text()
 		queryStruct, err := parser.Parse(query)
 		queryStruct = formatter.Format(queryStruct)
 		if err != nil {

--- a/lister/lister_test.go
+++ b/lister/lister_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestCreateUniqueQuerylist(t *testing.T) {
-	queries := `"SELECT * FROM user WHERE name = "test""
-"SELECT * FROM user WHERE name = "test""
-"SELECT * FROM user"`
+	queries := `SELECT * FROM user WHERE name = "test"
+SELECT * FROM user WHERE name = "test"
+SELECT * FROM user`
 	expectList := mapset.NewSet("SELECT * FROM user WHERE name = ?", "SELECT * FROM user")
 
 	list, _ := Create(strings.NewReader(queries))


### PR DESCRIPTION
ref: https://github.com/Komei22/sqd/pull/7
経緯は上記リンク参照．

入力フォーマットを`SELECT * FROM users\nWHERE name = \"hoge\"`のようなJSONログから，1クエリの文字列を1行に記述するフォーマットに変更します．JSONログを入力にしていたのは，改行を含むクエリへ対応するためだったのですが，このようなクエリは予め改行を排除した上でsqdに入力するものとします．